### PR TITLE
(maint) Include keeper player costs in selections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ coverage/
 # Temporary files
 tmp/
 temp/
+
+.claude

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -103,6 +103,9 @@ class KeeperApp {
 
     handlePlayerSelection(event) {
         const playerName = event.target.dataset.name;
+        const playerDiv = event.target.closest('.player-item');
+        const thisYearCostElements = playerDiv.querySelectorAll('.cost-value');
+        const thisYearCost = thisYearCostElements[1].textContent.replace('$', ''); // Second cost-value is "This Year"
         
         if (event.target.checked) {
             if (this.selectedPlayers.size >= 3) {
@@ -110,9 +113,14 @@ class KeeperApp {
                 this.showError('Maximum 3 keepers allowed');
                 return;
             }
-            this.selectedPlayers.add(playerName);
+            this.selectedPlayers.add({name: playerName, cost: thisYearCost});
         } else {
-            this.selectedPlayers.delete(playerName);
+            // Remove by name since we're storing objects now
+            this.selectedPlayers.forEach(player => {
+                if (player.name === playerName) {
+                    this.selectedPlayers.delete(player);
+                }
+            });
         }
         
         this.hideError();

--- a/src/routes/keepers.js
+++ b/src/routes/keepers.js
@@ -50,15 +50,29 @@ router.post('/submit', async (req, res) => {
             return res.status(400).json({ error: 'Maximum 3 keepers allowed' });
         }
         
-        // Save encrypted keepers
-        const keepersData = players.join('/');
+        // Save encrypted keepers with prices
+        const keepersData = players.map(player => {
+            if (typeof player === 'string') {
+                // Handle legacy format (just player names)
+                return player;
+            } else {
+                // New format with name and cost
+                return `${player.name} $${player.cost}`;
+            }
+        }).join('/');
         await encryptionService.saveEncryptedKeepers(team, keepersData, password);
         
         res.json({ 
             success: true,
             message: 'Keepers saved successfully',
             team,
-            keepers: players
+            keepers: players.map(player => {
+                if (typeof player === 'string') {
+                    return player;
+                } else {
+                    return `${player.name} $${player.cost}`;
+                }
+            })
         });
     } catch (error) {
         res.status(500).json({ error: error.message });


### PR DESCRIPTION
The keeper selection system previously only tracked player names when users made their keeper selections. The frontend would display both the previous year's cost and the calculated keeper cost for each player, but only the player name was stored when selections were submitted and encrypted.

This change modifies both the frontend and backend to capture and store the keeper cost alongside the player name. The frontend now extracts the "This Year" cost when a player is selected and stores it as an object with both name and cost properties. The backend processes these selections to format them as "Player Name $Cost" when encrypting the data, while maintaining backward compatibility with the legacy string-only format.

The goal is to preserve the calculated keeper costs in the encrypted selections so that when selections are decrypted later, the exact costs are available so I can cut and paste them into the draft.