### PR TITLE
fix: Resolve CSV parsing issues with comma-separated player names

### DIFF
--- a/rosters/ff2024rosters.csv
+++ b/rosters/ff2024rosters.csv
@@ -1,4 +1,4 @@
-ADAM,,JODI,,RAMAN,,GREG,,ELISA,,LANCE,,STEVE,,JACKIE,,MITCH,,LEAH,
+ADAM,,JODI,,RAMAN,,GREG,,ELISA,,LANCE,,STEVE,,JACKIE,,MITCH,,SANJAY,
 Player,$,Player,$,Player,$,Player,$,Player,$,Player,$,Player,$,Player,$,Player,$,Player,$
 "Darnold, Sam",11,"Mayfield, Baker",7,"Burrow, Joe",17,"Allen, Josh",11,"Murray, Kyler",7,"Love, Jordan",6,"Jackson, Lamar",29,"Goff, Jared",2,"Stroud, C.J.",2,"Carr, Derek",1
 "Williams, Kyren",7,"Mixon, Joe",24,"Cook, James",30,"Gibbs, Jahmyr",39,"Robinson, Bijan",55,"Jones, Aaron",11,"Taylor, Jonathan",10,"Barkley, Saquon",46,"Swift, D'Andre",25,"Pacheco, Isiah",8

--- a/src/services/csvService.js
+++ b/src/services/csvService.js
@@ -22,43 +22,52 @@ class CsvService {
     }
 
     parseRosterData(csvContent) {
-        const lines = csvContent.trim().split('\n');
+        // Parse CSV using the csv-parse library
+        const records = parse(csvContent, {
+            skip_empty_lines: true,
+            relax_quotes: true,
+            relax_column_count: true
+        });
+
         const teams = [];
         const players = {};
-        
-        // First line contains team names
-        const teamLine = lines[0].replace(/"/g, '').split(',,');
-        teamLine.forEach(team => {
-            if (team) {
-                teams.push(team);
-                players[team] = [];
+
+        // First line contains team names (separated by empty columns)
+        const teamLine = records[0];
+        for (let i = 0; i < teamLine.length; i += 2) {
+            if (teamLine[i]) {
+                teams.push(teamLine[i]);
+                players[teamLine[i]] = [];
             }
-        });
-        
-        // Skip header line with "Player,$,Player,$..."
-        for (let i = 2; i < lines.length; i++) {
-            const line = lines[i].replace(/"/g, '');
-            if (!line.trim()) continue;
-            
-            const values = line.split(',');
-            let valueIndex = 0;
-            
+        }
+
+        // Skip header line with "Player,$,Player,$..." at index 1
+        // Process player data starting from line 2
+        for (let i = 2; i < records.length; i++) {
+            const row = records[i];
+
             teams.forEach((team, teamIndex) => {
-                const playerName = values[valueIndex];
-                const playerCost = values[valueIndex + 1];
-                
-                if (playerName && playerCost) {
+                const colIndex = teamIndex * 2;
+                const rawPlayerName = row[colIndex];
+                const playerCost = row[colIndex + 1];
+
+                if (rawPlayerName && playerCost) {
+                    // Handle "lastname, firstname" format - convert to "firstname lastname"
+                    let playerName = rawPlayerName;
+                    if (rawPlayerName.includes(',')) {
+                        const [lastName, firstName] = rawPlayerName.split(',').map(s => s.trim());
+                        playerName = `${firstName} ${lastName}`;
+                    }
+
                     players[team].push({
                         name: playerName,
                         lastYearCost: parseInt(playerCost) || 0,
                         thisYearCost: this.calculateKeeperCost(parseInt(playerCost) || 0)
                     });
                 }
-                
-                valueIndex += 2;
             });
         }
-        
+
         return { teams, players };
     }
 


### PR DESCRIPTION
Previously, the manual string splitting approach failed to handle quoted CSV fields containing commas, causing player names like "Smith, John" to be parsed incorrectly. This resulted in the frontend displaying only last names and showing $0 prices due to malformed data structures.

This commit replaces manual string splitting with the csv-parse library to properly handle quoted CSV fields. Additionally, it converts player names from "Lastname, Firstname" format to "Firstname Lastname" format for consistent display. Also updates team name from "LEAH" to "SANJAY" in the 2024 roster file.