### PR TITLE
(feat) Add View All Teams feature with compact roster display

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -116,6 +116,12 @@ h2 {
   font-weight: 500;
 }
 
+.team-selection-buttons {
+  display: flex;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
 .btn:hover {
   background: #6f5f82;
   transform: translateY(-1px);
@@ -663,5 +669,106 @@ body.sticky-submit-visible {
   
   .player-name {
     font-size: 1rem;
+  }
+}
+
+/* All Teams View - Compact Layout */
+.all-teams-container {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.team-section {
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-card);
+  padding: 0.75rem;
+  box-shadow: var(--shadow-card);
+}
+
+.team-name {
+  color: var(--accent-primary);
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+  border-bottom: 1px solid var(--border-primary);
+  padding-bottom: 0.5rem;
+  text-align: center;
+}
+
+.team-players-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.compact-player-card {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-small);
+  padding: 0.4rem 0.6rem;
+  transition: all 0.2s ease;
+}
+
+.compact-player-card:hover {
+  background: rgba(74, 144, 226, 0.05);
+  border-color: var(--border-secondary);
+}
+
+.compact-player-info {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.compact-player-name {
+  font-weight: 500;
+  color: var(--text-primary);
+  font-size: 0.85rem;
+  flex: 1;
+  margin-right: 0.5rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.compact-cost {
+  color: var(--text-secondary);
+  font-weight: 600;
+  font-size: 0.85rem;
+  white-space: nowrap;
+}
+
+/* Responsive adjustments for all teams view */
+@media (max-width: 768px) {
+  .all-teams-container {
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 0.75rem;
+  }
+  
+  .team-selection-buttons {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+  
+  .team-selection-buttons .btn {
+    width: 100%;
+  }
+}
+
+@media (max-width: 480px) {
+  .all-teams-container {
+    grid-template-columns: 1fr 1fr;
+    gap: 0.5rem;
+  }
+  
+  .compact-player-name {
+    font-size: 0.8rem;
+  }
+  
+  .compact-cost {
+    font-size: 0.8rem;
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -19,7 +19,18 @@
                 <select id="teamSelect" class="form-control">
                     <option value="">Choose your team...</option>
                 </select>
-                <button id="selectTeamBtn" class="btn btn-primary">Select Team</button>
+                <div class="team-selection-buttons">
+                    <button id="selectTeamBtn" class="btn btn-primary">Select Team</button>
+                    <button id="viewAllTeamsBtn" class="btn btn-secondary">View All Teams</button>
+                </div>
+            </div>
+
+            <!-- View All Teams -->
+            <div id="viewAllTeams" class="section hidden">
+                <h2>All Team Rosters</h2>
+                <p class="info">View all teams and their potential keeper costs</p>
+                <div id="allTeamsContainer" class="all-teams-container"></div>
+                <button id="backToSelection" class="btn btn-primary">Back to Team Selection</button>
             </div>
 
             <!-- Player Selection -->

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -20,6 +20,10 @@ class KeeperApp {
         this.submitKeepersBtn = document.getElementById('submitKeepers');
         this.changeTeamBtn = document.getElementById('changeTeam');
         this.selectAnotherBtn = document.getElementById('selectAnother');
+        this.viewAllTeamsBtn = document.getElementById('viewAllTeamsBtn');
+        this.viewAllTeamsSection = document.getElementById('viewAllTeams');
+        this.allTeamsContainer = document.getElementById('allTeamsContainer');
+        this.backToSelectionBtn = document.getElementById('backToSelection');
         this.errorMessage = document.getElementById('errorMessage');
         this.progressIndicator = document.getElementById('progressIndicator');
         this.salaryCapDisplay = document.getElementById('salaryCapDisplay');
@@ -36,6 +40,8 @@ class KeeperApp {
         this.submitKeepersBtn.addEventListener('click', () => this.submitKeepers());
         this.changeTeamBtn.addEventListener('click', () => this.showTeamSelection());
         this.selectAnotherBtn.addEventListener('click', () => this.showTeamSelection());
+        this.viewAllTeamsBtn.addEventListener('click', () => this.showAllTeams());
+        this.backToSelectionBtn.addEventListener('click', () => this.showTeamSelection());
     }
 
     async loadTeams() {
@@ -246,10 +252,58 @@ class KeeperApp {
         this.updateStickySubmit();
     }
 
+    showAllTeams() {
+        if (!this.teamsData) {
+            this.showError('Teams data not loaded yet');
+            return;
+        }
+        
+        this.displayAllTeams();
+        this.hideAllSections();
+        this.viewAllTeamsSection.classList.remove('hidden');
+    }
+
+    displayAllTeams() {
+        this.allTeamsContainer.innerHTML = '';
+        
+        const teams = this.teamsData.teams;
+        teams.forEach(teamName => {
+            const teamPlayers = this.teamsData.players[teamName];
+            const normalizedTeamName = this.normalizeTeamName(teamName);
+            
+            const teamSection = document.createElement('div');
+            teamSection.className = 'team-section';
+            
+            teamSection.innerHTML = `
+                <h3 class="team-name">${normalizedTeamName}</h3>
+                <div class="team-players-grid">
+                    ${teamPlayers.map(player => `
+                        <div class="compact-player-card">
+                            <div class="compact-player-info">
+                                <span class="compact-player-name">${player.name}</span>
+                                <span class="compact-cost">$${player.thisYearCost}</span>
+                            </div>
+                        </div>
+                    `).join('')}
+                </div>
+            `;
+            
+            this.allTeamsContainer.appendChild(teamSection);
+        });
+    }
+
+    normalizeTeamName(teamName) {
+        return teamName.toLowerCase()
+            .split(' ')
+            .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+            .join(' ');
+    }
+
     hideAllSections() {
         this.teamSection.classList.add('hidden');
         this.playerSection.classList.add('hidden');
         this.confirmationSection.classList.add('hidden');
+        this.viewAllTeamsSection.classList.add('hidden');
         this.stickySubmit.classList.add('hidden');
         document.body.classList.remove('sticky-submit-visible');
         this.hideError();


### PR DESCRIPTION
Previously, users could only view one team's roster at a time after selecting from a dropdown, making it difficult to compare keeper options and costs across multiple teams without repeatedly switching views.

This commit introduces a "View All Teams" button that displays all team rosters in a single, high-density grid layout. The view shows normalized team names in proper case and simplified player information (names and keeper costs only), enabling quick comparison of keeper options across the entire league. The feature includes responsive design and navigation between the team selection and all-teams views.