### PR TITLE
(feat) Add theme toggle between dark and light modes

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -2,7 +2,7 @@
 
 /* CSS Custom Properties (Design Tokens) */
 :root {
-  /* Color Palette */
+  /* Dark Theme Color Palette (Default) */
   --bg-primary: #1a1a1a;
   --bg-secondary: #2d2d2d;
   --bg-tertiary: #2a2a2a;
@@ -24,6 +24,26 @@
   --radius-panel: 12px;
   --radius-card: 8px;
   --radius-small: 4px;
+}
+
+/* Light Theme Variables */
+[data-theme="light"] {
+  --bg-primary: #ffffff;
+  --bg-secondary: #f8f9fa;
+  --bg-tertiary: #f1f3f4;
+  --border-primary: #dee2e6;
+  --border-secondary: #adb5bd;
+  --text-primary: #212529;
+  --text-secondary: #495057;
+  --text-muted: #6c757d;
+  --accent-primary: #0d6efd;
+  --success: #198754;
+  --error: #dc3545;
+  --warning: #fd7e14;
+
+  /* Shadows */
+  --shadow-panel: 0 4px 12px rgba(0, 0, 0, 0.1);
+  --shadow-card: 0 2px 8px rgba(0, 0, 0, 0.1);
 }
 
 /* Base Styles */
@@ -56,6 +76,12 @@ header {
   margin-bottom: 2rem;
   text-align: center;
   box-shadow: var(--shadow-panel);
+}
+
+[data-theme="light"] header {
+  background: linear-gradient(135deg, #e9ecef 0%, #f8f9fa 100%);
+  color: var(--text-primary);
+  border: 1px solid var(--border-primary);
 }
 
 h1 {
@@ -352,6 +378,25 @@ h2 {
   color: #2a2a2a; /* Dark text for readability */
 }
 
+/* Light theme position badge variations */
+[data-theme="light"] .position-badge.position-RB {
+  background: #198754;
+  border: 1px solid #157347;
+  color: white;
+}
+
+[data-theme="light"] .position-badge.position-WR {
+  background: #fd7e14;
+  border: 1px solid #e8690b;
+  color: white;
+}
+
+[data-theme="light"] .position-badge.position-TE {
+  background: #dc3545;
+  border: 1px solid #bb2d3b;
+  color: white;
+}
+
 .position-badge.position-K {
   background: #5f82b5; /* Bright blue */
   border: 1px solid #7fa2d5;
@@ -468,6 +513,11 @@ h2 {
   padding: 0;
 }
 
+[data-theme="light"] .sticky-submit {
+  background: linear-gradient(135deg, #e9ecef 0%, #f8f9fa 100%);
+  box-shadow: 0 -6px 20px rgba(0, 0, 0, 0.1);
+}
+
 .sticky-submit-content {
   max-width: 1200px;
   margin: 0 auto;
@@ -491,9 +541,17 @@ h2 {
   font-size: 1rem;
 }
 
+[data-theme="light"] #stickyProgressText {
+  color: var(--text-primary);
+}
+
 .submit-budget {
   font-size: 0.85rem;
   color: #cbd5e0;
+}
+
+[data-theme="light"] .submit-budget {
+  color: var(--text-secondary);
 }
 
 .submit-budget.near-budget {
@@ -536,6 +594,21 @@ h2 {
 
 .password-input::placeholder {
   color: var(--text-muted);
+}
+
+/* Theme Toggle Button */
+.theme-toggle {
+  min-width: 44px;
+  padding: 0.5rem 0.75rem;
+  font-size: 1.2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.3s ease;
+}
+
+.theme-toggle:hover {
+  transform: translateY(-1px) scale(1.1);
 }
 
 /* Sticky Error Message */

--- a/public/index.html
+++ b/public/index.html
@@ -76,6 +76,7 @@
                     </div>
                     <button id="submitKeepers" class="btn btn-success" disabled>Submit Keepers</button>
                     <button id="changeTeam" class="btn btn-secondary">Change Team</button>
+                    <button id="themeToggle" class="btn btn-secondary theme-toggle" title="Toggle theme">🌙</button>
                 </div>
                 <div id="stickyErrorMessage" class="sticky-error hidden"></div>
             </div>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -6,6 +6,7 @@ class KeeperApp {
         
         this.initializeElements();
         this.attachEventListeners();
+        this.initializeTheme();
         this.loadTeams();
     }
 
@@ -32,6 +33,7 @@ class KeeperApp {
         this.stickyBudgetText = document.getElementById('stickyBudgetText');
         this.passwordSection = document.getElementById('passwordSection');
         this.stickyErrorMessage = document.getElementById('stickyErrorMessage');
+        this.themeToggle = document.getElementById('themeToggle');
         this.errorTimeout = null;
     }
 
@@ -42,6 +44,7 @@ class KeeperApp {
         this.selectAnotherBtn.addEventListener('click', () => this.showTeamSelection());
         this.viewAllTeamsBtn.addEventListener('click', () => this.showAllTeams());
         this.backToSelectionBtn.addEventListener('click', () => this.showTeamSelection());
+        this.themeToggle.addEventListener('click', () => this.toggleTheme());
     }
 
     async loadTeams() {
@@ -435,6 +438,31 @@ class KeeperApp {
         } else {
             this.passwordSection.classList.add('hidden');
             this.submitKeepersBtn.disabled = true;
+        }
+    }
+
+    initializeTheme() {
+        // Load saved theme preference or default to dark
+        const savedTheme = localStorage.getItem('theme') || 'dark';
+        this.setTheme(savedTheme);
+    }
+
+    toggleTheme() {
+        const currentTheme = document.documentElement.getAttribute('data-theme') || 'dark';
+        const newTheme = currentTheme === 'light' ? 'dark' : 'light';
+        this.setTheme(newTheme);
+        localStorage.setItem('theme', newTheme);
+    }
+
+    setTheme(theme) {
+        if (theme === 'light') {
+            document.documentElement.setAttribute('data-theme', 'light');
+            this.themeToggle.textContent = '☀️';
+            this.themeToggle.title = 'Switch to dark theme';
+        } else {
+            document.documentElement.removeAttribute('data-theme');
+            this.themeToggle.textContent = '🌙';
+            this.themeToggle.title = 'Switch to light theme';
         }
     }
 }


### PR DESCRIPTION
Previously the application only supported a dark theme, which limited user preference options and could affect accessibility for users preferring lighter interfaces.

This implementation adds a comprehensive theme toggle system where dark theme remains the default while light theme is available via CSS data-theme attribute selectors. A theme toggle button with moon and sun emojis was added to the sticky footer for easy access. The JavaScript includes theme switching logic with localStorage persistence to save user preferences across sessions. All UI components including header, footer, cards, and position badges were updated to support both themes while maintaining responsive design and accessibility.