### PR TITLE
(feat) Add layout toggle for player card display options

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -256,6 +256,30 @@ h2 {
   color: var(--text-primary);
 }
 
+/* Layout Controls */
+.layout-controls {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 1rem;
+}
+
+.layout-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  font-size: 0.9rem;
+  transition: all 0.3s ease;
+}
+
+.layout-toggle:hover {
+  transform: translateY(-1px);
+}
+
+.layout-icon {
+  font-size: 1.1rem;
+}
+
 /* Player Cards */
 .player-list {
   display: grid;
@@ -341,6 +365,41 @@ h2 {
   font-weight: bold;
   font-size: 1rem;
   color: var(--text-secondary);
+}
+
+/* List Layout Styles */
+.player-list.list-layout {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.player-list.list-layout .player-card {
+  display: flex;
+  align-items: center;
+  padding: 1rem 1.5rem;
+}
+
+.player-list.list-layout .player-info {
+  flex: 1;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.player-list.list-layout .player-name {
+  margin-bottom: 0;
+  flex: 1;
+}
+
+.player-list.list-layout .player-costs {
+  flex-direction: row;
+  gap: 2rem;
+  margin-left: 2rem;
+}
+
+.player-list.list-layout .cost {
+  min-width: 80px;
 }
 
 /* Position Badge Styles */
@@ -675,6 +734,10 @@ body.sticky-submit-visible {
   
   .player-list {
     grid-template-columns: 1fr;
+  }
+  
+  .layout-controls {
+    justify-content: center;
   }
   
   .player-costs {

--- a/public/index.html
+++ b/public/index.html
@@ -49,6 +49,14 @@
                     </div>
                 </div>
                 
+                <!-- Layout Controls -->
+                <div class="layout-controls">
+                    <button id="layoutToggle" class="btn btn-secondary layout-toggle" title="Toggle layout">
+                        <span class="layout-icon">⊞</span>
+                        <span class="layout-text">Grid View</span>
+                    </button>
+                </div>
+                
                 <div id="playerList" class="player-list"></div>
             </div>
 

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -7,6 +7,7 @@ class KeeperApp {
         this.initializeElements();
         this.attachEventListeners();
         this.initializeTheme();
+        this.initializeLayout();
         this.loadTeams();
     }
 
@@ -34,6 +35,7 @@ class KeeperApp {
         this.passwordSection = document.getElementById('passwordSection');
         this.stickyErrorMessage = document.getElementById('stickyErrorMessage');
         this.themeToggle = document.getElementById('themeToggle');
+        this.layoutToggle = document.getElementById('layoutToggle');
         this.errorTimeout = null;
     }
 
@@ -45,6 +47,7 @@ class KeeperApp {
         this.viewAllTeamsBtn.addEventListener('click', () => this.showAllTeams());
         this.backToSelectionBtn.addEventListener('click', () => this.showTeamSelection());
         this.themeToggle.addEventListener('click', () => this.toggleTheme());
+        this.layoutToggle.addEventListener('click', () => this.toggleLayout());
     }
 
     async loadTeams() {
@@ -463,6 +466,33 @@ class KeeperApp {
             document.documentElement.removeAttribute('data-theme');
             this.themeToggle.textContent = '🌙';
             this.themeToggle.title = 'Switch to light theme';
+        }
+    }
+
+    initializeLayout() {
+        // Load saved layout preference or default to grid
+        const savedLayout = localStorage.getItem('layout') || 'grid';
+        this.setLayout(savedLayout);
+    }
+
+    toggleLayout() {
+        const currentLayout = this.playerList.classList.contains('list-layout') ? 'list' : 'grid';
+        const newLayout = currentLayout === 'grid' ? 'list' : 'grid';
+        this.setLayout(newLayout);
+        localStorage.setItem('layout', newLayout);
+    }
+
+    setLayout(layout) {
+        if (layout === 'list') {
+            this.playerList.classList.add('list-layout');
+            this.layoutToggle.querySelector('.layout-icon').textContent = '☰';
+            this.layoutToggle.querySelector('.layout-text').textContent = 'List View';
+            this.layoutToggle.title = 'Switch to grid view';
+        } else {
+            this.playerList.classList.remove('list-layout');
+            this.layoutToggle.querySelector('.layout-icon').textContent = '⊞';
+            this.layoutToggle.querySelector('.layout-text').textContent = 'Grid View';
+            this.layoutToggle.title = 'Switch to list view';
         }
     }
 }


### PR DESCRIPTION
Previously the application only displayed player cards in a fixed grid layout, which limited viewing options for users who might prefer different visual arrangements for better readability or scanning.

This implementation adds a layout toggle system that allows users to switch between grid and list views. The default grid view maintains the existing responsive 3-column layout, while the new list view displays players in a single-column format with horizontal cards showing names and costs side-by-side. The toggle button is positioned above the player list with clear visual indicators and includes localStorage persistence to remember user preferences across sessions. The responsive design ensures both layouts work effectively on desktop and mobile devices.